### PR TITLE
Label Pull Requests

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -1,0 +1,40 @@
+# labels auto assigned to PR, keep in sync with labels.yml
+documentation:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["README.md", "*.md", "docs/**"]
+rust:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["**/*.rs", "Cargo.toml"]
+markdown:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              [
+                "docs/*.md",
+                "*.md",
+                "LICENSE",
+                ".github/pull_request_template.md",
+              ]
+dependencies:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["**/cargo.lock"]
+      - head-branch: ["^dependabot"]
+just:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["Justfile", "**/*.just"]
+shell:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["**/*.sh"]
+github_actions:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: [".github/workflows/*", ".github/actions/*"]
+git_hooks:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["githooks/**"]

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -1,0 +1,36 @@
+name: "Pull Request Tasks"
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  labeller:
+    name: Label Pull Request
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label Pull Request
+        uses: actions/labeler@v5.0.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/other-configurations/labeller.yml
+          sync-labels: true
+      - name: Add Size Labels
+        uses: pascalgn/size-label-action@v0.5.5
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          sizes: >
+            {
+              "0": "XS",
+              "40": "S",
+              "100": "M",
+              "200": "L",
+              "800": "XL",
+              "2000": "XXL"
+            }


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to automate the labeling of pull requests based on modified files and to add size labels to pull requests based on the number of lines changed. The most important changes include the addition of a configuration file for the labeler and a workflow file to handle the pull request tasks.

Labeling and size automation:

* [`.github/other-configurations/labeller.yml`](diffhunk://#diff-b490f987d9b055ce6e06e37d13763d61f6e0d5ee349b390bbb910f8d88ff36b9R1-R40): Added configuration for auto-assigning labels to pull requests based on changed files. This includes labels for documentation, Rust files, markdown files, dependencies, Justfiles, shell scripts, GitHub Actions, and git hooks.
* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfR1-R36): Added a workflow to label pull requests and add size labels. This workflow triggers on pull request events and uses the `actions/labeler` and `pascalgn/size-label-action` actions to apply the appropriate labels.

Fixes #22 
