### PR TITLE
Add Dependabot Dependency Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
+    target-branch: "main"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new configuration file for Dependabot to automate dependency updates for GitHub Actions.

Configuration for Dependabot:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R19): Added a new configuration file to set up weekly updates for GitHub Actions dependencies. The updates are scheduled for Saturdays at 01:00 London time and target the main branch. The configuration includes groups for patch and minor updates.

Fixes #23 
