### PR TITLE
Add Zizmor Scanning

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -1,0 +1,37 @@
+name: "Code Checks"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  run-zizmor:
+    name: Check GitHub Actions with zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5.1.0
+        with:
+          version: "latest"
+      - name: Run zizmor 🌈
+        run: uvx zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3.28.0
+        with:
+          sarif_file: results.sarif
+          category: zizmor


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub Actions workflow for performing code checks using `zizmor`. The workflow is configured to run on specific events and includes steps for checking out the repository, installing dependencies, running the `zizmor` tool, and uploading the results.

Key changes:

* Added a new workflow configuration in `.github/workflows/code-checks.yml` to perform code checks using `zizmor`.
  * The workflow triggers on `push` to the `main` branch and on various pull request events.
  * It includes steps for checking out the repository, installing the latest version of `uv`, running `zizmor`, and uploading the SARIF results.

Fixes #28 
