### PR TITLE
Add Markdown Link Checker

### DIFF
--- a/.github/other-configurations/.linkspector.yml
+++ b/.github/other-configurations/.linkspector.yml
@@ -1,0 +1,5 @@
+dirs:
+  - ./
+  - ./docs
+aliveStatusCodes:
+  - 200

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -11,6 +11,24 @@ permissions:
   packages: read
 
 jobs:
+  check-markdown-links:
+    name: Check Markdown links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check Markdown links
+        uses: UmbrellaDocs/action-linkspector@v1.2.4
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          config_file: .github/other-configurations/.linkspector.yml
+          reporter: github-pr-review
+          fail_on_error: true
+          filter_mode: nofilter
+
   run-zizmor:
     name: Check GitHub Actions with zizmor
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new workflow to check for broken Markdown links in the repository. It includes the addition of a configuration file for the link-checking tool and updates the GitHub Actions workflow to integrate this new check.

Configuration for link-checking tool:

* [`.github/other-configurations/.linkspector.yml`](diffhunk://#diff-f9691f23ea6c4c34ecbaa23a98721e0aa3c7a94f2fcdd38f7b99fe863c5f6305R1-R5): Added configuration file specifying directories to scan and status codes for alive links.

GitHub Actions workflow update:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R14-R31): Added a new job to check Markdown links using the `UmbrellaDocs/action-linkspector` action. This job checks out the repository, runs the link-checking tool with the specified configuration, and reports any issues as GitHub PR reviews.

Fixes #18 
