### PR TITLE
Add Justfile Format Checking

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -54,6 +54,20 @@ jobs:
           fail_on_error: true
           filter_mode: nofilter
 
+  check-justfile-format:
+    name: Check Justfile Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Just
+        uses: extractions/setup-just@v2
+      - name: Check Justfile Format
+        run: just just-format-check
+
   run-zizmor:
     name: Check GitHub Actions with zizmor
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new job to the GitHub Actions workflow to ensure the format of the `Justfile` is checked. The most important change is the addition of the `check-justfile-format` job in the `.github/workflows/code-checks.yml` file.

Improvements to the GitHub Actions workflow:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R57-R70): Added a new job named `check-justfile-format` to verify the format of the `Justfile`. This job includes steps for checking out the repository, setting up Just, and running the format check command.

Fixes #19 
