### PR TITLE
Run Rust Lint Checks

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -88,6 +88,26 @@ jobs:
         env:
           CARGO_TERM_COLOR: always
 
+  check-rust-linting:
+    name: Check Rust Linting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Just
+        uses: extractions/setup-just@v2
+      - name: Setup Rust Toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
+        with:
+          components: clippy
+      - name: Check Rust Format
+        run: just rust-lint-check
+        env:
+          CARGO_TERM_COLOR: always
+
   run-zizmor:
     name: Check GitHub Actions with zizmor
     runs-on: ubuntu-latest

--- a/Justfile
+++ b/Justfile
@@ -2,8 +2,21 @@
 # Rust Commands
 # ------------------------------------------------------------------------------
 
+# Check for Rust clippy issues
+rust-lint-check:
+    cargo clippy
+
+# Fix Rust clippy issues
+rust-lint-fix:
+    cargo clippy --fix
+
+# Check for Rust formatting issues
 rust-fmt-check:
     cargo fmt -- --check
+
+# Fix Rust formatting issues
+rust-fmt:
+    cargo fmt
 
 # ------------------------------------------------------------------------------
 # Prettier - File Formatting


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new workflow for Rust linting and formatting checks in the GitHub Actions configuration. The main changes include adding a new job to check Rust linting and updating the `Justfile` to include commands for Rust linting and formatting.

### GitHub Actions Workflow Enhancements:
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R91-R110): Added a new job `check-rust-linting` to perform Rust linting using Clippy. This job checks out the repository, sets up Just, and installs the Rust toolchain with Clippy before running the lint check.

### Justfile Updates:
* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cR5-R20): Added new commands `rust-lint-check` and `rust-lint-fix` for checking and fixing Rust Clippy issues, respectively. Also added `rust-fmt` for fixing Rust formatting issues.

Fixes #45 
